### PR TITLE
Use the new fullchain-filename exposed by app-lets-encrypt 1.10.6 to …

### DIFF
--- a/deploy/info.php
+++ b/deploy/info.php
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 $app['basename'] = 'openfire';
-$app['version'] = '1.2.5';
+$app['version'] = '1.2.6';
 $app['release'] = '1';
 $app['vendor'] = 'WikiSuite';
 $app['packager'] = 'eGloo';

--- a/libraries/Openfire.php
+++ b/libraries/Openfire.php
@@ -328,13 +328,17 @@ class Openfire extends Daemon
         //-------------------
 
         $details = $certificate_manager->get_certificate($certificate);
+        if (array_key_exists('fullchain-filename', $details))
+            $cert_filename = $details['fullchain-filename'];
+        else
+            $cert_filename = $details['certificate-filename'];
 
         $shell = new Shell();
         $shell->execute(
             self::COMMAND_OPENSSL,
             'pkcs12 -export ' .
             '-name ' . $certificate . ' ' .
-            '-out ' . self::FILE_PKCS12 . ' -inkey ' . $details['key-filename']  . ' -in ' . $details['certificate-filename'] . ' ' .
+            '-out ' . self::FILE_PKCS12 . ' -inkey ' . $details['key-filename']  . ' -in ' . $cert_filename . ' ' .
             '-password "pass:' . self::CONSTANT_KEYSTORE_PW . '"',
             TRUE
         );

--- a/packaging/app-openfire.spec
+++ b/packaging/app-openfire.spec
@@ -1,7 +1,7 @@
 
 Name: app-openfire
 Epoch: 1
-Version: 1.2.5
+Version: 1.2.6
 Release: 1%{dist}
 Summary: Openfire
 License: GPLv3


### PR DESCRIPTION
…fix SSL connection issue in XMPP clients caused by incorrect certificate being imported.  Like nginx, openfire needs fullchain.pem

This is the companion pull request for https://github.com/WikiSuite/app-lets-encrypt/pull/12 , but will work fine (well, no worse than before) without it.